### PR TITLE
Remove private token from installer script download function

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -25,7 +25,7 @@ download_file() {
   local dest="$2"
 
   echo -e "${BLUE}Downloading: ${url} -> ${dest}${NC}"
-  curl -sLo "${dest}" --header "PRIVATE-TOKEN: glpat-s6joFZTq8adhvwUx5Rcz" "${url}"
+  curl -sLo "${dest}" "${url}"
 }
 
 download_file "${FUNCTIONS_LIB_URL}" "${FUNCTIONS_LIB_PATH}"


### PR DESCRIPTION
Eliminate the use of a private token in the download function to enhance security.