### PR TITLE
Correcting version number

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -50,7 +50,7 @@ cat << "EOF"
  *              AudioStack              *
  *              Installer               *
  *  Made with ♥ by Broadcast Utilities  *
- *                V1.1.0                *
+ *                V1.0.0                *
  ****************************************
 EOF
 


### PR DESCRIPTION
This pull request includes a small change to the `installer.sh` file. The change updates the version number displayed in the installer from `V1.1.0` to `V1.0.0`.