### PR TITLE
Adding licensing info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ This structured failover mechanism ensures continuous audio delivery in all scen
 - Tested on **Ubuntu 24.04**
 - Supports **x86_64** architectures
 - Requires an **active internet connection** for resolving external script dependencies
+
+## License
+This project is licensed under the MIT License. See the [LICENSE](LICENSE.md) file for details.


### PR DESCRIPTION
This pull request includes an update to the `README.md` file to add licensing information.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R41-R43): Added a section to specify that the project is licensed under the MIT License and provided a link to the `LICENSE.md` file.