### PR TITLE
Update installer script and stream description

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -341,13 +341,16 @@ chmod 644 "${CONFIG_DIR}/${CONFIGNAME}.wav"
 chown -R 1000:1000 "${CONFIG_DIR}/${CONFIGNAME}.wav"
 
 
-
+# ========================================================
+# Cleanup
+# ========================================================
+echo -e "${BLUE}Cleaning up...${NC}"
 rm -rf "${CONFIG_DIR}/old_logs/*"
 
+
 # ========================================================
-# Cleanup & Secure Credentials
+# Display Completion Message
 # ========================================================
-unset GITLAB_USER GITLAB_TOKEN
 echo -e "${GREEN}Installation completed successfully for ${HOSTNAME}!${NC}"
 echo -e "${GREEN}Icecast is now running at http://${HOSTNAME}:${PORT}${NC}"
 echo -e "${GREEN}Liquidsoap is running with inputs on ports ${INPUT_1_PORT} and ${INPUT_2_PORT}${NC}"

--- a/installer.sh
+++ b/installer.sh
@@ -341,12 +341,6 @@ chmod 644 "${CONFIG_DIR}/${CONFIGNAME}.wav"
 chown -R 1000:1000 "${CONFIG_DIR}/${CONFIGNAME}.wav"
 
 
-# ========================================================
-# Cleanup
-# ========================================================
-echo -e "${BLUE}Cleaning up...${NC}"
-rm -rf "${CONFIG_DIR}/old_logs/*"
-
 
 # ========================================================
 # Display Completion Message

--- a/installer.sh
+++ b/installer.sh
@@ -314,7 +314,7 @@ output_icecast_stream(
     transmux = 'adts',
     sbr_mode = true
   ),
-  description="Mobile Stream (96kbit AAC)",
+  description="LQ Stream (96kbit AAC)",
   mount="/${SLUG}.aac",
   source=audio_to_icecast
 )


### PR DESCRIPTION
Removed unset GITLAB_USER GITLAB_TOKEN.

Added a cleanup step before the completion message in the installer script and update the stream description in the `output_icecast_stream` function. Remove the previous cleanup step to streamline the installation process.

Fixes #10